### PR TITLE
fix: add NUXT_TYPE_NAME_LIST to build command in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           node-version: "24"
       - run: npm install
-      - run: NUXT_BASE_URL=/verse-closet/ NUXT_BRAND_NAME_LIST="${{ vars.NUXT_BRAND_NAME_LIST }}" NUXT_CARD_POOL_LIST="${{ vars.NUXT_CARD_POOL_LIST }}" NUXT_SCRIPTS_GOOGLE_ANALYTICS_ID="${{ vars.NUXT_SCRIPTS_GOOGLE_ANALYTICS_ID }}" npx nuxt build --preset github_pages
+      - run: NUXT_BASE_URL=/verse-closet/ NUXT_BRAND_NAME_LIST="${{ vars.NUXT_BRAND_NAME_LIST }}" NUXT_TYPE_NAME_LIST="${{ vars.NUXT_TYPE_NAME_LIST }}" NUXT_CARD_POOL_LIST="${{ vars.NUXT_CARD_POOL_LIST }}" NUXT_SCRIPTS_GOOGLE_ANALYTICS_ID="${{ vars.NUXT_SCRIPTS_GOOGLE_ANALYTICS_ID }}" npx nuxt build --preset github_pages
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
This pull request makes a small update to the deployment workflow by adding a new environment variable to the Nuxt build command.

- Deployment workflow update:
  * [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L20-R20): Added the `NUXT_TYPE_NAME_LIST` environment variable to the Nuxt build step, allowing the build process to utilize this new configuration.